### PR TITLE
chore:Fixing missing docker compose

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,6 +47,12 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+      
+    - name: Set up Docker
+      uses: docker/setup-docker@v2
+
+    - name: Install Docker Compose
+      run: sudo apt-get update && sudo apt-get install -y docker-compose
 
     - name: Run E2E tests in Go container
       run: ./e2e_tests.sh


### PR DESCRIPTION
### Summary
This PR makes sure the GHA installs docker compose for running e2e tests